### PR TITLE
fix(print): make Skills / Technologies and Knowledge section full width in print view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -843,4 +843,14 @@ ul.keywords {
     .acc-title {
         font-size: 13px !important
     }
+
+    .sectionSkill .item,
+    #skills .item,
+    .accordion .item {
+        width: 100% !important;
+        max-width: 100% !important;
+        box-sizing: border-box;
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
 }


### PR DESCRIPTION
This PR updates the print CSS to ensure the Skills / Technologies and Knowledge section is full width, matching other sections for a consistent print layout.